### PR TITLE
Update TotalPaid to support 0, adds Logout endpoint

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -102,7 +102,10 @@ func (s *Server) logout() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		resp := response.New(w)
 		defer resp.Output()
-		//get the refresh token
+		// Set the refresh_token to force an override of any
+		// existing cookies. This cookie is set as already expired.
+		// This needs to be done as it's a HttpOnly cookie,
+		// so this cannot be deleted from the client.
 		http.SetCookie(w, &http.Cookie{
 			Name:     "refresh_token",
 			Value:    "",

--- a/server/auth.go
+++ b/server/auth.go
@@ -98,22 +98,22 @@ func (s *Server) login() http.HandlerFunc {
 	}
 }
 
-func(s  *Server) logout() http.HandlerFunc {
-    return func(w http.ResponseWriter, r *http.Request) {
-        resp := response.New(w)
-        defer resp.Output()
-        //get the refresh token
-        http.SetCookie(w, &http.Cookie {
-            Name:     "refresh_token",
-            Value:    "",
-            Expires:  time.Unix(0,0),
-            Path:     "/",
-            Secure:   true,
-            HttpOnly: true,
-            SameSite: http.SameSiteStrictMode,
-        })
-        resp.SetResult(http.StatusOK, nil)
-    }
+func (s *Server) logout() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		resp := response.New(w)
+		defer resp.Output()
+		//get the refresh token
+		http.SetCookie(w, &http.Cookie{
+			Name:     "refresh_token",
+			Value:    "",
+			Expires:  time.Unix(0, 0),
+			Path:     "/",
+			Secure:   true,
+			HttpOnly: true,
+			SameSite: http.SameSiteStrictMode,
+		})
+		resp.SetResult(http.StatusOK, nil)
+	}
 }
 
 func (s *Server) authRefresh() http.HandlerFunc {

--- a/server/auth.go
+++ b/server/auth.go
@@ -98,6 +98,24 @@ func (s *Server) login() http.HandlerFunc {
 	}
 }
 
+func(s  *Server) logout() http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        resp := response.New(w)
+        defer resp.Output()
+        //get the refresh token
+        http.SetCookie(w, &http.Cookie {
+            Name:     "refresh_token",
+            Value:    "",
+            Expires:  time.Unix(0,0),
+            Path:     "/",
+            Secure:   true,
+            HttpOnly: true,
+            SameSite: http.SameSiteStrictMode,
+        })
+        resp.SetResult(http.StatusOK, nil)
+    }
+}
+
 func (s *Server) authRefresh() http.HandlerFunc {
 	refreshTokenRepo := models.RefreshTokenRepository{DB: s.DB}
 

--- a/server/payments.go
+++ b/server/payments.go
@@ -117,7 +117,7 @@ func (s *Server) createPayment() http.HandlerFunc {
 	type RequestBody struct {
 		BillId    string  `json:"bill_id" validate:"required"`
 		DueDate   string  `json:"due_date" validate:"required,datetime=2006-01-02"`
-		TotalPaid float64 `json:"total_paid" validate:"required,gte=0"`
+		TotalPaid float64 `json:"total_paid" validate:"gte=0"`
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		resp := response.New(w)

--- a/server/server.go
+++ b/server/server.go
@@ -41,7 +41,7 @@ func (s *Server) registerRoutes() {
 	// Auth Endpoints
 	s.Router.HandlerFunc(http.MethodPost, "/users", s.createUser())
 	s.Router.HandlerFunc(http.MethodPost, "/auth/login", s.login())
-    s.Router.HandlerFunc(http.MethodPost, "/auth/logout", s.logout())
+	s.Router.HandlerFunc(http.MethodPost, "/auth/logout", s.logout())
 	s.Router.HandlerFunc(http.MethodPost, "/auth/refresh", s.authRefresh())
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -41,6 +41,7 @@ func (s *Server) registerRoutes() {
 	// Auth Endpoints
 	s.Router.HandlerFunc(http.MethodPost, "/users", s.createUser())
 	s.Router.HandlerFunc(http.MethodPost, "/auth/login", s.login())
+    s.Router.HandlerFunc(http.MethodPost, "/auth/logout", s.logout())
 	s.Router.HandlerFunc(http.MethodPost, "/auth/refresh", s.authRefresh())
 }
 


### PR DESCRIPTION
https://pkg.go.dev/gopkg.in/go-playground/validator.v9#hdr-Required
"This validates that the value is not the data types default zero value. For numbers ensures value is not zero."

For TotalPaid field, the zero value should be able to be added when marking as paid. The "required" syntax(?) returns a validation error and the user cannot enter 0.00.
